### PR TITLE
Modal close

### DIFF
--- a/CepInput.php
+++ b/CepInput.php
@@ -96,12 +96,12 @@ class CepInput extends InputWidget
      */
     protected function renderModal()
     {
-        echo Html::beginTag('div', ['class' => 'fade modal', 'role' => 'dialog', 'tabindex' => '-1']);
+        echo Html::beginTag('div', ['class' => 'fade modal cep-modal', 'role' => 'dialog', 'tabindex' => '-1']);
         echo Html::beginTag('div', ['class' => 'modal-dialog modal-lg']);
         echo Html::beginTag('div', ['class' => 'modal-content']);
 
         echo Html::beginTag('div', ['class' => 'modal-header']);
-        echo Html::button('&times;', ['class' => 'close', 'data-dismiss' => 'modal', 'aria-hidden' => true]);
+        echo Html::button('&times;', ['class' => 'close close-modal', 'aria-hidden' => true]);
         echo "CEP";
         echo Html::endTag('div');
 
@@ -115,7 +115,7 @@ class CepInput extends InputWidget
         echo Html::endTag('div');
 
         echo Html::beginTag('div', ['class' => 'modal-footer']);
-        echo Html::button('Fechar', ['class' => 'btn btn-default', 'data-dismiss' => 'modal', 'aria-hidden' => true]);
+        echo Html::button('Fechar', ['class' => 'btn btn-default close-modal', 'aria-hidden' => true]);
         echo Html::endTag('div');
 
         echo Html::endTag('div');

--- a/assets/jquery.cep.js
+++ b/assets/jquery.cep.js
@@ -3,6 +3,10 @@
  * Released under the MIT license.
  */
 (function ($) {
+    $('.close-modal').on('click', function(){
+        $(".cep-modal").modal("hide");
+    });
+    
     var Cep = function ($element, options) {
         this.init($element, options);
     };


### PR DESCRIPTION
When we use one modal within another, the "data-dismiss" of the modal child closes all open modals. I had an impasse when I went to use the zip search in a modal, just because of this, when we closed the zip modal the parent modal was also closed. So I made some adjustments to solve this problem. I do not know if it was the right way, but it worked.